### PR TITLE
Fix stale associations when removing charms

### DIFF
--- a/src/main/java/com/merlin/category/CategoryService.java
+++ b/src/main/java/com/merlin/category/CategoryService.java
@@ -75,6 +75,8 @@ public class CategoryService {
                 .orElseThrow(() -> new RuntimeException("Charm not found"));
 
         category.getCharms().remove(charm);
+        // Ensure the relationship is cleared on the charm side as well
+        charm.setCategory(null);
         categoryRepo.save(category);
     }
 

--- a/src/main/java/com/merlin/user/UserService.java
+++ b/src/main/java/com/merlin/user/UserService.java
@@ -42,6 +42,8 @@ public class UserService {
                 .orElseThrow(() -> new RuntimeException("Charm not found"));
 
         user.getCharms().remove(charm);
+        // Clear the relationship on the charm to keep the association consistent
+        charm.setUser(null);
         userRepository.save(user);
     }
 


### PR DESCRIPTION
## Summary
- clear charm category reference when detaching from a category
- clear charm user reference when detaching from a user

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689711663d688333837f76fb34bb73ee